### PR TITLE
HUP rspamd on log rotation

### DIFF
--- a/src/etc/newsyslog.conf
+++ b/src/etc/newsyslog.conf
@@ -15,4 +15,4 @@
 /var/log/pflog				600  3     250  *     ZB "pkill -HUP -u root -U root -t - -x pflogd"
 /var/www/logs/access.log		644  4     *    $W0   Z "pkill -USR1 -u root -U root -x httpd"
 /var/www/logs/error.log			644  7     250  *     Z "pkill -USR1 -u root -U root -x httpd"
-/var/log/rspamd/rspamd.log _rspamd:_rspamd 640  1     300  *     Z
+/var/log/rspamd/rspamd.log _rspamd:_rspamd 640  1     300  *     Z "pkill -HUP -u _rspamd -U _rspamd -x rspamd"


### PR DESCRIPTION
rspamd won't write to the new log file until it's HUP'd