### PR TITLE
Prefer rsa-sha256 dkim signature rather than rsa-sha1

### DIFF
--- a/src/etc/dkimproxy_out.conf
+++ b/src/etc/dkimproxy_out.conf
@@ -8,7 +8,7 @@ relay     localhost:10028
 domain    example.com,example.net
 
 # specify what signatures to add
-signature dkim(c=relaxed)
+signature dkim(c=relaxed, a=rsa-sha256)
 signature domainkeys(c=nofws)
 
 # specify location of the private 1024 bits key


### PR DESCRIPTION
Also, using sha-1 violates: https://tools.ietf.org/html/rfc8301#section-3