### PR TITLE
Use IPv6 too

### DIFF
--- a/src/etc/httpd.conf
+++ b/src/etc/httpd.conf
@@ -1,6 +1,13 @@
 # $OpenBSD: httpd.conf,v 1.16 2016/09/17 20:05:59 tj Exp $
 
 #
+# Macros
+#
+
+IPv4="*"
+IPv6="::"
+
+#
 # Global Options
 #
 
@@ -12,8 +19,10 @@ prefork 1
 
 # Host
 server "mercury.example.com" {
-	listen on egress port http
-	listen on egress tls port https
+	listen on $IPv4 port http
+	listen on $IPv4 tls port https
+	listen on $IPv6 port http
+	listen on $IPv6 tls port https
 
 	hsts subdomains
 
@@ -43,11 +52,13 @@ server "mercury.example.com" {
 
 # IP defender (!) must be last server
 server "nonexistent" {
-	alias match "%d+%.%d+%.%d+%.%d+"
-	alias match "%w*::*"
+	alias match "%d+%.%d+%.%d+%.%d+" # IPv4 or IPv6
+	alias match "%w*::*" # IPv6
 
-	listen on egress port http
-	listen on egress port https # (!) no tls
+	listen on $IPv4 port http
+	listen on $IPv4 port https # (!) no tls
+	listen on $IPv6 port http
+	listen on $IPv6 port https # (!) no tls
 
 	tcp nodelay
 	connection { max requests 500, timeout 3600 }


### PR DESCRIPTION
For httpd, the primary IP address of the network interface that is a member of the “egress” group can only be one type (IPv4 preferred)