### PR TITLE
Add mailbox autocreation; Add Listescape plugin

### DIFF
--- a/src/etc/dovecot/conf.d/10-mail.conf
+++ b/src/etc/dovecot/conf.d/10-mail.conf
@@ -27,7 +27,8 @@
 #
 # <doc/wiki/MailLocation.txt>
 #
-#mail_location = 
+# Mailbox autocreation <https://wiki2.dovecot.org/MailLocation>
+mail_location = maildir:/var/vmail/%d/%n/Maildir:LAYOUT=Maildir++
 
 # If you need to set multiple mailbox locations or want to change default
 # namespace settings, you can do it by defining namespace sections.
@@ -46,7 +47,7 @@ namespace inbox {
   # Hierarchy separator to use. You should use the same separator for all
   # namespaces or some clients get confused. '/' is usually a good one.
   # The default however depends on the underlying mail storage format.
-  separator = / # default:
+  separator = / # "/" with Listescape plugin, default:
 
   # Prefix required to access this namespace. This needs to be different for
   # all namespaces. For example "Public/".
@@ -213,7 +214,7 @@ mail_plugin_dir = /usr/local/lib/dovecot
 
 # Space separated list of plugins to load for all services. Plugins specific to
 # IMAP, LDA, etc. are added to this list in their own .conf files.
-mail_plugins = $mail_plugins quota trash zlib notify replication # fts fts_squat
+mail_plugins = $mail_plugins quota trash zlib notify replication listescape # fts fts_squat
 
 ##
 ## Mailbox handling optimizations

--- a/src/etc/dovecot/conf.d/90-plugin.conf
+++ b/src/etc/dovecot/conf.d/90-plugin.conf
@@ -9,25 +9,31 @@
 plugin {
   #setting_name = value
 
-  # Trash Plugin (https://wiki2.dovecot.org/Plugins/Trash)
+  # Listescape plugin <https://wiki2.dovecot.org/Plugins/Listescape>
+  # The default escape character is '\', but you can change it.
+  # Note that even here the expansion of % takes place, thus you need to
+  # use "%%" if you want to have the % sign as the escape character.
+  #listescape_char = "\\"
+
+  # Trash Plugin <https://wiki2.dovecot.org/Plugins/Trash>
   trash = /etc/dovecot/dovecot-trash.conf.ext
 
-  # Zlib plugin (https://wiki.dovecot.org/Plugins/Zlib)
+  # Zlib plugin <https://wiki.dovecot.org/Plugins/Zlib>
   zlib_save_level = 6 # 1..9; default is 6
   zlib_save = gz # or bz2, xz or lz4
 
-  # FTS Plugin (https://wiki2.dovecot.org/Plugins/FTS)
+  # FTS Plugin <https://wiki2.dovecot.org/Plugins/FTS>
   #fts_autoindex = yes
-  # Squat Full Text Search Indexing (https://wiki2.dovecot.org/Plugins/FTS/Squat)
+  # Squat Full Text Search Indexing <https://wiki2.dovecot.org/Plugins/FTS/Squat>
   #fts = squat
   #fts_squat = partial=4 full=10
-  # Lucene Full Text Search Indexing (https://wiki2.dovecot.org/Plugins/FTS/Lucene)
+  # Lucene Full Text Search Indexing <https://wiki2.dovecot.org/Plugins/FTS/Lucene>
   #fts = lucene
   # Lucene-specific settings, good ones are:
   #fts_lucene = whitespace_chars=@.
 
-  # Pigeonhole IMAPSieve Plugins (https://wiki2.dovecot.org/Pigeonhole/Sieve/Plugins/IMAPSieve)
-  # (!) https://rspamd.com/doc/tutorials/feedback_from_users_with_IMAPSieve.html
+  # Pigeonhole IMAPSieve Plugins <https://wiki2.dovecot.org/Pigeonhole/Sieve/Plugins/IMAPSieve>
+  # (!) <https://rspamd.com/doc/tutorials/feedback_from_users_with_IMAPSieve.html>
   #
   # From elsewhere to Spam folder
   imapsieve_mailbox1_name = Spam


### PR DESCRIPTION
- Use "mail_location" for mailbox autocreation
  <https://wiki2.dovecot.org/MailLocation>
- Allow '.' characters with Maildir++ layout when virtual hierarchy separator is changed to '/'
  <https://wiki2.dovecot.org/Plugins/Listescape>