### PR TITLE
Rename "pf.permanentban" to "pf.conf.table.ban"

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -233,7 +233,7 @@ install -o root -g wheel -m 0640 -b src/etc/httpd.conf* /etc/
 install -o root -g wheel -m 0644 -b src/etc/login.conf /etc/
 install -o root -g wheel -m 0644 -b src/etc/newsyslog.conf /etc/
 install -o root -g wheel -m 0600 -b src/etc/pf.conf* /etc/
-install -o root -g wheel -m 0600 -b src/etc/pf.permanentban /etc/
+install -o root -g wheel -m 0600 -b src/etc/pf.conf.table.ban /etc/
 install -o root -g wheel -m 0644 -b src/etc/resolv.conf.tail /etc/
 install -o root -g wheel -m 0644 -b src/etc/sysctl.conf /etc/
 
@@ -596,12 +596,12 @@ dig +short example.meh mx
 
 for each bad subdomain, add its IP (A and AAAA record) to `pf`:
 ```sh
-echo $IP >> /etc/pf.permanentban
+echo $IP >> /etc/pf.conf.table.ban
 ```
 
 and reload the `pf` table:
 ```sh
-pfctl -t permanentban -T replace -f /etc/pf.permanentban
+pfctl -t ban -T replace -f /etc/pf.conf.table.ban
 ```
 
 ### Microsoft Network

--- a/README.md
+++ b/README.md
@@ -161,19 +161,22 @@ wkd.example.net.	86400	IN	CNAME	mercury.example.com.
 #### SRV Records for OpenPGP [Web Key Directory](https://wiki.gnupg.org/WKD)
 Each domain has record type SRV for WKD subdomain
 ```console
-_openpgpkey._tcp.example.com	86400	IN	SRV	0 0 443 wkd.example.com
+_openpgpkey._tcp.example.com	86400	IN	SRV	0 0 443	wkd.example.com
 ```
 
 Each *virtual* domain has record type SRV for *virtual* WKD subdomain
 ```console
-_openpgpkey._tcp.example.net	86400	IN	SRV	0 0 443 wkd.example.net
+_openpgpkey._tcp.example.net	86400	IN	SRV	0 0 443	wkd.example.net
 ```
 
 #### SRV Records for [Locating Email Services](https://tools.ietf.org/html/rfc6186)
 Each domain and *virtual* domain has record types SRV for simple MUA auto-configuration:
 ```console
-_submission._tcp.example.com.	86400	IN	SRV	0 1 587 mercury.example.com.
-_imaps._tcp.example.com.	86400	IN	SRV	0 1 993 mercury.example.com.
+_submission._tcp.example.com.	86400	IN	SRV	0 1 587	mercury.example.com.
+_imap._tcp.example.com.		86400	IN	SRV	0 0 0	.
+_imaps._tcp.example.com.	86400	IN	SRV	0 1 993	mercury.example.com.
+_pop3._tcp.example.com.		86400	IN	SRV	0 0 0	.
+_pop3s._tcp.example.com.	86400	IN	SRV	0 0 0	.
 ```
 
 #### Mail eXchanger ([MX](https://tools.ietf.org/html/rfc5321))

--- a/src/etc/pf.conf
+++ b/src/etc/pf.conf
@@ -28,7 +28,7 @@ table <martians> const persist counters { \
  2001:db8::/32 fc00::/7 }
 
 # Bad hosts
-table <permanentban> persist counters file "/etc/pf.permanentban"
+table <ban> persist counters file "/etc/pf.conf.table.ban"
 
 # fuzzy_check (server:port) rspamd.com:11335
 table <rspamd> { 88.99.142.95 }

--- a/src/etc/pf.conf.anchor.block
+++ b/src/etc/pf.conf.anchor.block
@@ -24,7 +24,7 @@ anchor "in-quick-bad" in on egress {
 
  # Block incoming traffic from the undesirable
  block $logblock quick \
-  from { <martians> no-route urpf-failed <permanentban> }
+  from { <martians> no-route urpf-failed <ban> }
 }
 
 anchor "out-quick-bad" out on egress {

--- a/src/etc/pf.conf.table.ban
+++ b/src/etc/pf.conf.table.ban
@@ -1,0 +1,1 @@
+# /sbin/pfctl -t ban -T replace -f /etc/pf.conf.table.ban


### PR DESCRIPTION
- Indicate IMAP, POP3, and POP3S are not supported, rfc6186
- Rename "pf.permanentban" to "pf.conf.table.ban"
- Rename `pf` table "permanentban" to "ban"