### PR TITLE
Allow outgoing DSN and MDN with empty reverse path "MAIL FROM: <>"

### DIFF
--- a/src/etc/mail/smtpd.conf
+++ b/src/etc/mail/smtpd.conf
@@ -168,4 +168,13 @@ match	tag MSA \
 	!for local \
 	auth \
 	action "dkim"
+#
+# Outgoing messages (DSN and MDN with empty reverse path "MAIL FROM: <>")
+# from localhost to dkimproxy_out for signing (RFC1123 section 5.2.9)
+match	!tag MSA \
+	helo localhost \
+	from local \
+	!for local \
+	!mail-from <localhost> \
+	action "dkim"
 


### PR DESCRIPTION
- RFC1123 section 5.2.9