### PR TITLE
Update smtpd.conf

### DIFF
--- a/src/etc/mail/smtpd.conf
+++ b/src/etc/mail/smtpd.conf
@@ -19,12 +19,10 @@ mta	max-deferred \
 	100
 # Pass the message through Rspamd and delegate message delivery to Dovecot LDA
 mda	wrapper	dovecot \
-	"/usr/local/bin/rspamc \
-			-t 120 \
-			-h /var/run/rspamd/rspamd.sock \
-			--mime \
-			-e \"/usr/local/libexec/dovecot/dovecot-lda \
-				-a %{rcpt} -d %{dest}\""
+	"rspamc -h /var/run/rspamd/rspamd.sock \
+		-t 120 \
+		--mime \
+		-e '%{mda}'"
 
 
 # PKI
@@ -124,7 +122,10 @@ action	"lmtp" \
 #
 # Delegate message delivery to wrapper "dovecot" using virtual expansion
 action	"mda" \
-	mda "/nonexistent" \
+	mda "/usr/local/libexec/dovecot/dovecot-lda \
+		-a %{rcpt} \
+		-d %{dest} \
+		-f %{mbox.from}" \
 	virtual <virtuals> \
 	wrapper "dovecot"
 


### PR DESCRIPTION
- dovecot-lda doesn't know how to cope with empty sender,
  and wants MAILER-DAEMON string: -f %{mbox.from} thank you @poolpOrg
- use %{mda}