### PR TITLE
Update 10-ssl.conf to reflect recent changes

### DIFF
--- a/src/etc/dovecot/conf.d/10-ssl.conf
+++ b/src/etc/dovecot/conf.d/10-ssl.conf
@@ -48,7 +48,7 @@ ssl_key = </etc/ssl/acme/private/mercury.example.com.key
 #ssl_dh_parameters_length = 1024
 
 # SSL protocols to use
-ssl_protocols = TLSv1.2 # default: !SSLv3
+ssl_min_protocol = TLSv1.2 # default: !SSLv3
 
 # SSL ciphers to use
 ssl_cipher_list = HIGH:!AES128:!kRSA:!aNULL # default: ALL:!LOW:!SSLv2:!EXP:!aNULL

--- a/src/etc/httpd.conf
+++ b/src/etc/httpd.conf
@@ -23,18 +23,21 @@ server "mercury.example.com" {
 
 	listen on $IP tls port https # (!) TLS
 
-	hsts subdomains
-
-	tls certificate "/etc/ssl/acme/mercury.example.com.fullchain.pem"
-	tls key "/etc/ssl/acme/private/mercury.example.com.key"
-	# (!) see usr/local/bin/get-ocsp.sh
-	tls ocsp "/etc/ssl/acme/mercury.example.com.ocsp.resp.der"
-
-	# Cipher Strength <https://man.openbsd.org/SSL_CTX_set_cipher_list>
-	tls ciphers "HIGH:!AES128:!kRSA:!aNULL" # default: "HIGH:!aNULL"
-	# Key Exchange <https://man.openbsd.org/tls_config_set_ecdhecurves>
-	tls ecdhe "P-384,P-256,X25519" # default: "X25519,P-256,P-384"
-
+	hsts {
+		preload
+		subdomains
+	}
+	tls {
+		certificate "/etc/ssl/acme/mercury.example.com.fullchain.pem"
+		key "/etc/ssl/acme/private/mercury.example.com.key"
+		# (!) see usr/local/bin/get-ocsp.sh
+		ocsp "/etc/ssl/acme/mercury.example.com.ocsp.resp.der"
+		# Cipher Strength <https://man.openbsd.org/SSL_CTX_set_cipher_list>
+		ciphers "HIGH:!AES128:!kRSA:!aNULL" # default: "HIGH:!aNULL"
+		# Key Exchange <https://man.openbsd.org/tls_config_set_ecdhecurves>
+		ecdhe "P-384,P-256,X25519" # default: "X25519,P-256,P-384"
+	}
+	
 	tcp nodelay
 	connection { max requests 500, timeout 3600 }
 


### PR DESCRIPTION
Dovecot 2.3, as shipped with OpenBSD-current, warns that ssl_protocols was deprecated and replaced with ssl_min_protocol.