### PR TITLE
Only update passwd table needs root privileges

### DIFF
--- a/src/etc/mail/passwd
+++ b/src/etc/mail/passwd
@@ -1,6 +1,6 @@
 # https://wiki.dovecot.org/PasswordDatabase
-# `smtpctl update table passwd`
+# `doas smtpctl update table passwd`
 #
 ## You can create passwords with:
-## `doas smtpctl encrypt`
+## `smtpctl encrypt`
 puffy@example.com:$2b$08$al9rCnC14amLM5O.QVy3/usDFIf/kiClTurJiMFMNDqnr06gw83/O::::::


### PR DESCRIPTION
Only update passwd table needs root privileges, `smtpctl encrypt` does not need that.